### PR TITLE
connector: fix avatar download for relative URLs from Zulip

### DIFF
--- a/pkg/connector/chatinfo.go
+++ b/pkg/connector/chatinfo.go
@@ -2,6 +2,7 @@ package connector
 
 import (
 	"context"
+        "strings"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -94,53 +95,56 @@ func (zc *ZulipClient) wrapChannelInfo(channel channels.ChannelInfo, members []i
 }
 
 func (zc *ZulipClient) GetUserInfo(ctx context.Context, ghost *bridgev2.Ghost) (*bridgev2.UserInfo, error) {
-	user, err := users.NewService(zc.Client).GetUser(ctx, zid.ParseUserID(ghost.ID))
-	if err != nil {
-		return nil, err
-	}
-	return wrapUserInfo(user.User)
+        user, err := users.NewService(zc.Client).GetUser(ctx, zid.ParseUserID(ghost.ID))
+        if err != nil {
+                return nil, err
+        }
+        return wrapUserInfo(zc.ServerURL, user.User)
 }
 
 var AvatarClient = &http.Client{
 	Timeout: 20 * time.Second,
 }
 
-func wrapUserInfo(user users.UserData) (*bridgev2.UserInfo, error) {
-	var identifiers []string
-	if user.DeliveryEmail != "" {
-		identifiers = []string{"mailto:" + user.DeliveryEmail}
-	}
-	return &bridgev2.UserInfo{
-		Identifiers: identifiers,
-		Name:        &user.FullName,
-		Avatar:      wrapAvatar(user.AvatarVersion, user.AvatarURL, user.DeliveryEmail),
-		IsBot:       &user.IsBot,
-	}, nil
+func wrapUserInfo(serverURL string, user users.UserData) (*bridgev2.UserInfo, error) {
+        var identifiers []string
+        if user.DeliveryEmail != "" {
+                identifiers = []string{"mailto:" + user.DeliveryEmail}
+        }
+        return &bridgev2.UserInfo{
+                Identifiers: identifiers,
+                Name:        &user.FullName,
+                Avatar:      wrapAvatar(serverURL, user.AvatarVersion, user.AvatarURL, user.DeliveryEmail),
+                IsBot:       &user.IsBot,
+        }, nil
 }
 
-func wrapAvatar(version int, url, email string) *bridgev2.Avatar {
-	if url == "" {
-		if email == "" {
-			return nil
-		}
-		emailHash := sha256.Sum256([]byte(email))
-		url = fmt.Sprintf("https://www.gravatar.com/avatar/%x", emailHash[:])
-	}
-	return &bridgev2.Avatar{
-		ID: networkid.AvatarID(strconv.Itoa(version)),
-		Get: func(ctx context.Context) ([]byte, error) {
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-			if err != nil {
-				return nil, err
-			}
-			req.Header.Set("User-Agent", mautrix.DefaultUserAgent)
-			resp, err := AvatarClient.Do(req)
-			if err != nil {
-				return nil, err
-			} else if resp.StatusCode >= 300 {
-				return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
-			}
-			return io.ReadAll(resp.Body)
-		},
-	}
+func wrapAvatar(serverURL string, version int, avatarURL, email string) *bridgev2.Avatar {
+        url := avatarURL
+        if url == "" {
+                if email == "" {
+                        return nil
+                }
+                emailHash := sha256.Sum256([]byte(email))
+                url = fmt.Sprintf("https://www.gravatar.com/avatar/%x", emailHash[:])
+        } else if strings.HasPrefix(url, "/") {
+                url = strings.TrimRight(serverURL, "/") + url  // ← вот фикс
+        }
+        return &bridgev2.Avatar{
+                ID: networkid.AvatarID(strconv.Itoa(version)),
+                Get: func(ctx context.Context) ([]byte, error) {
+                        req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+                        if err != nil {
+                                return nil, err
+                        }
+                        req.Header.Set("User-Agent", mautrix.DefaultUserAgent)
+                        resp, err := AvatarClient.Do(req)
+                        if err != nil {
+                                return nil, err
+                        } else if resp.StatusCode >= 300 {
+                                return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
+                        }
+                        return io.ReadAll(resp.Body)
+                },
+        }
 }

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -19,6 +19,7 @@ type ZulipClient struct {
 	Main      *ZulipConnector
 	UserLogin *bridgev2.UserLogin
 	Client    *zulip.Client
+        ServerURL string
 
 	stopPoll    atomic.Pointer[context.CancelFunc]
 	pollStopped atomic.Pointer[chan struct{}]
@@ -43,6 +44,7 @@ func (zc *ZulipConnector) LoadUserLogin(ctx context.Context, login *bridgev2.Use
 		Client:    cli,
 		UserLogin: login,
 		ownUserID: zid.ParseUserLoginID(login.ID),
+                ServerURL: meta.URL,   // ← добавить здесь
 	}
 	return nil
 }


### PR DESCRIPTION
Zulip returns relative paths like /user_avatars/2/... when using local file storage. The bridge tried to use these as absolute URLs which caused 'unsupported protocol scheme' errors.

Fix: prepend the Zulip server URL when avatar_url starts with /.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
